### PR TITLE
fix: logic for setting number in number input changed

### DIFF
--- a/src/components/atoms/HookFormInputWrapper/HookFormInputWrapper.stories.js
+++ b/src/components/atoms/HookFormInputWrapper/HookFormInputWrapper.stories.js
@@ -12,13 +12,7 @@ export default metadata;
 function InputWrapper({ name, control, ...props }) {
   return (
     <HookFormInputWrapper control={control} name={name}>
-      <NumberInput
-        size="small"
-        variant="material"
-        label={name}
-        onChange={(value) => console.log("input value", value)}
-        {...props}
-      />
+      <NumberInput size="small" variant="material" label={name} {...props} />
     </HookFormInputWrapper>
   );
 }
@@ -39,7 +33,14 @@ const Template = () => {
         }}
       >
         <InputWrapper name={"NumberInput"} control={control} />
-        <InputWrapper name={"NumberInput (format)"} control={control} format />
+        <InputWrapper
+          name={"NumberInput fraction 0 "}
+          control={control}
+          parse
+          emptyValue={null}
+          format={{ maximumFractionDigits: 0 }}
+        />
+        <InputWrapper name={"NumberInput (parse)"} control={control} format />
         <InputWrapper
           name={"NumberInput (format and empty value)"}
           control={control}

--- a/src/components/atoms/NumberInput/NumberInput.tsx
+++ b/src/components/atoms/NumberInput/NumberInput.tsx
@@ -79,7 +79,7 @@ const NumberInput = forwardRef(
           newTextValue = `${newSplits[0]}.${newFormattedValue.split(".")[1]}`;
         }
         const unformattedValue = format
-          ? stringToNumber(newTextValue, emptyValue)
+          ? stringToNumber(newFormattedValue, emptyValue)
           : newTextValue;
         const newNumberValue =
           parse || isNil(unformattedValue)
@@ -90,7 +90,7 @@ const NumberInput = forwardRef(
         setNumberValue(unformattedValue);
         setTextValue(getTextValue(newTextValue, format));
       },
-      [format, onChange, onChangeValue, parse]
+      [emptyValue, format, onChange, onChangeValue, parse]
     );
 
     useEffect(() => {

--- a/src/components/atoms/NumberInput/NumberInput.tsx
+++ b/src/components/atoms/NumberInput/NumberInput.tsx
@@ -93,11 +93,6 @@ const NumberInput = forwardRef(
       [emptyValue, format, onChange, onChangeValue, parse]
     );
 
-    useEffect(() => {
-      setNumberValue(value);
-      setTextValue(getTextValue(value, format));
-    }, [format, value]);
-
     return (
       <div className={styles.root}>
         <TextInput


### PR DESCRIPTION
in the previous number input, whenever we were setting maxFractionDigits equals 0 and in the UI when we were typing fractions then the textvalue was changing but not the number value and because of which in the payload decimal was going.

also the useEffect to change both the state variable is removed as the setting is done on the onChange handler rather than in useEffect.