### PR TITLE
fix: added child props to control error handling in hookformwrapper

### DIFF
--- a/src/components/atoms/HookFormInputWrapper/HookFormInputWrapper.tsx
+++ b/src/components/atoms/HookFormInputWrapper/HookFormInputWrapper.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-hook-form";
 
 interface HookFormInputWrapperProps extends ControllerProps {
+  childProps?: Record<string, any>;
   children: ReactElement;
   control?: Control;
   onChange?: (...event: any[]) => void;
@@ -20,6 +21,7 @@ function prependToPropMethod(method, propMethod) {
 }
 
 export default function HookFormInputWrapper({
+  childProps,
   children,
   control,
   ...props
@@ -44,6 +46,7 @@ export default function HookFormInputWrapper({
             onChangeValue,
             ref,
             value,
+            ...childProps,
           })
         )
       }


### PR DESCRIPTION
with the recent merge the error was handled automatically inside the hookformwrapper. Now, by sending child props we can control if we want to handle the error internally or manually with other custom component.