### PR TITLE
feat: add latest code for hook-form-input-wrapper on 1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.12.14",
       "license": "MIT",
       "dependencies": {
+        "@hookform/error-message": "^2.0.1",
         "@tabler/icons-react": "^2.22.0",
         "animejs": "^3.2.1",
         "clsx": "^1.2.1",
@@ -4364,6 +4365,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@hookform/error-message": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/error-message/-/error-message-2.0.1.tgz",
+      "integrity": "sha512-U410sAr92xgxT1idlu9WWOVjndxLdgPUHEB8Schr27C9eh7/xUnITWpCMF93s+lGiG++D4JnbSnrb5A21AdSNg==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -38656,7 +38667,6 @@
       "version": "7.44.3",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.44.3.tgz",
       "integrity": "sha512-/tHId6p2ViAka1wECMw8FEPn/oz/w226zehHrJyQ1oIzCBNMIJCaj6ZkQcv+MjDxYh9MWR7RQic7Qqwe4a5nkw==",
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12.22.0"
@@ -50162,6 +50172,12 @@
           }
         }
       }
+    },
+    "@hookform/error-message": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/error-message/-/error-message-2.0.1.tgz",
+      "integrity": "sha512-U410sAr92xgxT1idlu9WWOVjndxLdgPUHEB8Schr27C9eh7/xUnITWpCMF93s+lGiG++D4JnbSnrb5A21AdSNg==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.10",
@@ -75512,7 +75528,6 @@
       "version": "7.44.3",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.44.3.tgz",
       "integrity": "sha512-/tHId6p2ViAka1wECMw8FEPn/oz/w226zehHrJyQ1oIzCBNMIJCaj6ZkQcv+MjDxYh9MWR7RQic7Qqwe4a5nkw==",
-      "optional": true,
       "peer": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "jest --coverage --json --outputFile=./reports/test-report.json"
   },
   "dependencies": {
+    "@hookform/error-message": "^2.0.1",
     "@tabler/icons-react": "^2.22.0",
     "animejs": "^3.2.1",
     "clsx": "^1.2.1",

--- a/src/components/atoms/FormError.tsx
+++ b/src/components/atoms/FormError.tsx
@@ -1,0 +1,23 @@
+import { MultipleFieldErrors } from "react-hook-form";
+
+import styles from "./formError.module.css";
+
+const CustomError = ({
+  messages,
+}: {
+  messages?: MultipleFieldErrors | string;
+}) => {
+  return (
+    messages && (
+      <div className={styles.root}>
+        {Object.entries(messages).map(([type, message]) => (
+          <p className={styles.item} key={type}>
+            {message}
+          </p>
+        ))}
+      </div>
+    )
+  );
+};
+
+export default CustomError;

--- a/src/components/atoms/HookFormInputWrapper/HookFormInputWrapper.tsx
+++ b/src/components/atoms/HookFormInputWrapper/HookFormInputWrapper.tsx
@@ -1,58 +1,100 @@
-import React, { ChangeEvent, ReactElement, useMemo } from "react";
-import { useController } from "react-hook-form";
+import type { Primitive, SetOptional } from "type-fest";
 
-interface HookFormInputWrapperProps {
-  children: any;
-  control: any;
-  name: string;
-  onChange?: (...event: any[]) => void;
-}
+import React, {
+  type ChangeEvent,
+  type ChangeEventHandler,
+  type ComponentPropsWithRef,
+  type FocusEvent,
+  type ReactElement,
+  type ReactNode,
+  Suspense,
+  useMemo,
+} from "react";
+import {
+  type ControllerProps,
+  type FieldValues,
+  useController,
+} from "react-hook-form";
 
-export default function HookFormInputWrapper({
+import FormError from "../FormError.js";
+
+const ErrorMessage = React.lazy(() =>
+  import("@hookform/error-message").then(({ ErrorMessage }) => ({
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    default: ErrorMessage,
+  })),
+);
+
+export type ChangeHandler = (
+  event: ChangeEvent<HTMLInputElement>,
+  value?: Primitive,
+  shouldUpdate?: boolean,
+) => void;
+
+export type HookFormInputWrapperProps<TValues extends FieldValues> =
+  SetOptional<ControllerProps<TValues>, "control" | "render"> & {
+    children: ReactElement<
+      ComponentPropsWithRef<"input"> & {
+        onChange: ChangeHandler;
+      }
+    >;
+    onChange?: ChangeEventHandler;
+    showError?: boolean;
+  };
+
+export default function HookFormInputWrapper<TValues extends FieldValues>({
   children,
   name,
+  showError,
   ...props
-}: HookFormInputWrapperProps): ReactElement {
+}: HookFormInputWrapperProps<TValues>): ReactNode {
   const {
     field: { onBlur, onChange, ref, value },
-    fieldState: { error },
-    formState: { defaultValues },
+    formState: { defaultValues, errors },
   } = useController({ name, ...props });
   const child = React.Children.only(children);
   const changeHandlers = useMemo(
     () => ({
-      onBlur: (event: FocusEvent) => {
+      onBlur: (event: FocusEvent<HTMLInputElement>) => {
         onBlur();
         child.props.onBlur?.(event);
       },
-      onChange: (
-        event: ChangeEvent<HTMLInputElement>,
-        value?: any,
-        shouldUpdate?: boolean,
-      ) => {
+      onChange: ((event, value, shouldUpdate) => {
         if (shouldUpdate) {
           onChange(value);
         } else if (value === undefined) {
           onChange(event);
         }
         child.props.onChange?.(event, value, shouldUpdate);
-      },
+      }) as ChangeHandler,
     }),
     [child.props, onBlur, onChange],
   );
 
   const cloneProps = useMemo(() => {
     const response = {
-      error,
       ref,
       value,
       ...changeHandlers,
     } as typeof child.props;
-    if (defaultValues[name] !== undefined) {
+    if (defaultValues?.[name] !== undefined) {
       response.defaultValue = defaultValues[name];
     }
     return response;
-  }, [changeHandlers, child, defaultValues, error, name, ref, value]);
+  }, [changeHandlers, child, defaultValues, name, ref, value]);
 
-  return React.cloneElement(child, cloneProps);
+  return (
+    <>
+      {React.cloneElement(child, cloneProps)}
+      {showError && (
+        <Suspense>
+          <ErrorMessage
+            errors={errors}
+            name={name}
+            render={({ messages }) => <FormError messages={messages} />}
+          />
+        </Suspense>
+      )}
+    </>
+  );
 }

--- a/src/components/atoms/HookFormInputWrapper/HookFormInputWrapper.tsx
+++ b/src/components/atoms/HookFormInputWrapper/HookFormInputWrapper.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable perfectionist/sort-objects */
 import type { Primitive, SetOptional } from "type-fest";
 
+import { isObject } from "lodash-es";
 import React, {
   type ChangeEvent,
   type ChangeEventHandler,
@@ -22,13 +24,13 @@ const ErrorMessage = React.lazy(() =>
   import("@hookform/error-message").then(({ ErrorMessage }) => ({
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     default: ErrorMessage,
-  })),
+  }))
 );
 
 export type ChangeHandler = (
   event: ChangeEvent<HTMLInputElement>,
   value?: Primitive,
-  shouldUpdate?: boolean,
+  shouldUpdate?: boolean
 ) => void;
 
 export type HookFormInputWrapperProps<TValues extends FieldValues> =
@@ -38,20 +40,21 @@ export type HookFormInputWrapperProps<TValues extends FieldValues> =
         onChange: ChangeHandler;
       }
     >;
+    hideError?: boolean;
     onChange?: ChangeEventHandler;
-    showError?: boolean;
   };
 
 export default function HookFormInputWrapper<TValues extends FieldValues>({
   children,
+  hideError,
   name,
-  showError,
   ...props
 }: HookFormInputWrapperProps<TValues>): ReactNode {
   const {
     field: { onBlur, onChange, ref, value },
     formState: { defaultValues, errors },
   } = useController({ name, ...props });
+
   const child = React.Children.only(children);
   const changeHandlers = useMemo(
     () => ({
@@ -68,7 +71,7 @@ export default function HookFormInputWrapper<TValues extends FieldValues>({
         child.props.onChange?.(event, value, shouldUpdate);
       }) as ChangeHandler,
     }),
-    [child.props, onBlur, onChange],
+    [child.props, onBlur, onChange]
   );
 
   const cloneProps = useMemo(() => {
@@ -86,12 +89,16 @@ export default function HookFormInputWrapper<TValues extends FieldValues>({
   return (
     <>
       {React.cloneElement(child, cloneProps)}
-      {showError && (
+      {!hideError && (
         <Suspense>
           <ErrorMessage
+            render={({ messages, message }) => (
+              <FormError
+                messages={isObject(messages) ? messages : { message }}
+              />
+            )}
             errors={errors}
             name={name}
-            render={({ messages }) => <FormError messages={messages} />}
           />
         </Suspense>
       )}

--- a/src/components/atoms/formError.module.css
+++ b/src/components/atoms/formError.module.css
@@ -1,0 +1,10 @@
+.root {
+  color: var(--color-negative);
+  font-weight: var(--ye-font-weight-normal);
+  font-size: var(--ye-font-size-xsmall);
+}
+
+.item {
+  margin: var(--ye-spacing-em-tiny) 0 0;
+  padding-bottom: var(--ye-spacing-em-tiny);
+}


### PR DESCRIPTION
The Show error prop is needed in the 1.x version. The changes for latest HookFormInputWrapper have been added to the 1.x branch.