### PR TITLE
fix: corrected css for long names in fileinput

### DIFF
--- a/src/components/atoms/FileInput/fileInput.module.css
+++ b/src/components/atoms/FileInput/fileInput.module.css
@@ -74,6 +74,7 @@
 
   .list-item-text {
     flex: 1;
+    hyphens: auto;
   }
 
   .list-item-data-input,


### PR DESCRIPTION
ecas upload file -> when the name of the file is very long, if overflow the container. 