### PR TITLE
fix: remove weird corners and outlines from loading buttons

### DIFF
--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -186,7 +186,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function ButtonRender(
         size && styles[`size-${size}`],
         variant && styles[`variant-${variant}`],
         {
-          [styles.isDisabled]: disabled,
+          [styles.isDisabled]: disabled || isBusy,
           [styles.isFullWidth]: isFullWidth,
         },
         spacing && styles[`spacing-${spacing}`],
@@ -221,7 +221,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function ButtonRender(
       {iconAfter && (
         <FormIconSpan className={styles.icon}>{iconAfter}</FormIconSpan>
       )}
-      {isBusy && <Spinner className={styles.spinner} />}
+      {isBusy && <Spinner />}
     </FormButtonControl>
   );
 });

--- a/src/components/atoms/Button/button.module.css
+++ b/src/components/atoms/Button/button.module.css
@@ -267,11 +267,6 @@
     }
   }
 
-  .spinner {
-    inset: 1px;
-    border-radius: var(--ye-button-border-radius);
-  }
-
   /* to avoid undef error */
   /* stylelint-disable-next-line no-descending-specificity */
   .variant-basic,

--- a/src/components/atoms/Spinner/spinner.module.css
+++ b/src/components/atoms/Spinner/spinner.module.css
@@ -6,7 +6,7 @@
     align-items: center;
     justify-content: center;
     color: var(--ye-color-black-50);
-    background-color: var(--ye-color-white-90);
+    background-color: transparent;
   }
 
   .spinner {


### PR DESCRIPTION
BEFORE
![image](https://github.com/tiwariav/ye-design/assets/70276198/7489cb0b-bb50-4efa-8606-a8e9c0f7baa5)

AFTER
<img width="371" alt="image" src="https://github.com/tiwariav/ye-design/assets/70276198/d9431d71-2d73-44d4-abf0-15b52f98b4fb">
